### PR TITLE
Document the format of the manual configuration file.

### DIFF
--- a/exo/helpers.py
+++ b/exo/helpers.py
@@ -370,3 +370,14 @@ def get_exo_images_dir() -> Path:
   images_dir = exo_home/"Images"
   if not images_dir.exists(): images_dir.mkdir(exist_ok=True)
   return images_dir
+
+def get_device_capabilities_json():
+  from exo.topology.device_capabilities import device_capabilities
+  loop = asyncio.new_event_loop()
+  asyncio.set_event_loop(loop)
+  try:
+    caps = loop.run_until_complete(device_capabilities())
+    caps_dict = caps.model_dump()
+    return json.dumps(caps_dict, indent=2)
+  finally:
+    loop.close()

--- a/exo/main.py
+++ b/exo/main.py
@@ -22,7 +22,7 @@ from exo.api import ChatGPTAPI
 from exo.download.shard_download import ShardDownloader, NoopShardDownloader
 from exo.download.download_progress import RepoProgressEvent
 from exo.download.new_shard_download import new_shard_downloader, has_exo_home_read_access, has_exo_home_write_access, ensure_exo_home, seed_models
-from exo.helpers import print_yellow_exo, find_available_port, DEBUG, get_system_info, get_or_create_node_id, get_all_ip_addresses_and_interfaces, terminal_link, shutdown
+from exo.helpers import print_yellow_exo, find_available_port, DEBUG, get_system_info, get_or_create_node_id, get_all_ip_addresses_and_interfaces, terminal_link, shutdown, get_device_capabilities_json
 from exo.inference.shard import Shard
 from exo.inference.inference_engine import get_inference_engine
 from exo.inference.tokenizers import resolve_tokenizer
@@ -77,6 +77,7 @@ parser.add_argument("--broadcast-port", type=int, default=5678, help="Broadcast 
 parser.add_argument("--discovery-module", type=str, choices=["udp", "tailscale", "manual"], default="udp", help="Discovery module to use")
 parser.add_argument("--discovery-timeout", type=int, default=30, help="Discovery timeout in seconds")
 parser.add_argument("--discovery-config-path", type=str, default=None, help="Path to discovery config json file")
+parser.add_argument("--get-device-capabilities", action="store_true", help="Output the current device's auto-detected capabilities in JSON format and exit")
 parser.add_argument("--wait-for-peers", type=int, default=0, help="Number of peers to wait to connect to before starting")
 parser.add_argument("--chatgpt-api-port", type=int, default=52415, help="ChatGPT API port")
 parser.add_argument("--chatgpt-api-response-timeout", type=int, default=900, help="ChatGPT API response timeout in seconds")
@@ -92,6 +93,12 @@ parser.add_argument("--node-id-filter", type=str, default=None, help="Comma sepa
 parser.add_argument("--interface-type-filter", type=str, default=None, help="Comma separated list of allowed interface types (only for UDP discovery)")
 parser.add_argument("--system-prompt", type=str, default=None, help="System prompt for the ChatGPT API")
 args = parser.parse_args()
+
+# Handle the --get-device-capabilities option before printing anything else so it can be used for automation
+if args.get_device_capabilities:
+    print(get_device_capabilities_json())
+    exit(0)
+
 print(f"Selected inference engine: {args.inference_engine}")
 
 print_yellow_exo()
@@ -149,6 +156,9 @@ elif args.discovery_module == "tailscale":
 elif args.discovery_module == "manual":
   if not args.discovery_config_path:
     raise ValueError(f"--discovery-config-path is required when using manual discovery. Please provide a path to a config json file.")
+  # Manual discovery uses a JSON config file that defines all nodes in the network
+  # The config file should contain a "peers" object mapping node_ids to their connection details
+  # See NetworkTopology class in exo/networking/manual/network_topology_config.py for the expected format
   discovery = ManualDiscovery(args.discovery_config_path, args.node_id, create_peer_handle=lambda peer_id, address, description, device_capabilities: GRPCPeerHandle(peer_id, address, description, device_capabilities))
 topology_viz = TopologyViz(chatgpt_api_endpoints=chatgpt_api_endpoints, web_chat_urls=web_chat_urls) if not args.disable_tui else None
 node = Node(

--- a/exo/networking/manual/network_topology_config.py
+++ b/exo/networking/manual/network_topology_config.py
@@ -16,6 +16,44 @@ class NetworkTopology(BaseModel):
   peers: Dict[str, PeerConfig]
   """
   node_id to PeerConfig. The node_id is used to identify the peer in the discovery process. The node that this is running from should be included in this dict.
+  
+  Example configuration file format:
+  ```json
+  {
+    "peers": {
+      "node1": {
+        "address": "192.168.1.10",
+        "port": 50051,
+        "device_capabilities": {
+          "model": "Mac Studio",
+          "chip": "Apple M3 Ultra",
+          "memory": 524288,
+          "flops": {
+            "fp32": 108.52,
+            "fp16": 54.26,
+            "int8": 217.04
+          }
+        }
+      },
+      "node2": {
+        "address": "192.168.1.20",
+        "port": 50051,
+        "device_capabilities": {
+          "model": "Desktop PC",
+          "chip": "NVIDIA GEFORCE GTX 1080 TI",
+          "memory": 11264,
+          "flops": {
+            "fp32": 11.34,
+            "fp16": 0.177,
+            "int8": 45.36
+          }
+        }
+      }
+    }
+  }
+  ```
+  
+  When running with manual discovery, make sure your node_id matches one of the keys in this peers dictionary.
   """
   @classmethod
   def from_path(cls, path: str) -> "NetworkTopology":


### PR DESCRIPTION
Add --get-device-capabilities that outputs the current device's device_capabilities object in JSON form, to allow external tooling to automate the creation of the manual config file.