### PR TITLE
fix bfloat16 stuff

### DIFF
--- a/exo/inference/mlx/sharded_inference_engine.py
+++ b/exo/inference/mlx/sharded_inference_engine.py
@@ -107,7 +107,7 @@ class MLXDynamicShardInferenceEngine(InferenceEngine):
 
     output_data_np = await asyncio.get_running_loop().run_in_executor(
       self._mlx_thread,
-      lambda: np.array(output_data, copy=False)
+      lambda: convert_output_to_numpy(output_data_mx)
     )
     return output_data_np, inference_state
 

--- a/exo/models.py
+++ b/exo/models.py
@@ -88,6 +88,7 @@ model_cards = {
   ### deepseek
   "deepseek-coder-v2-lite": { "layers": 27, "repo": { "MLXDynamicShardInferenceEngine": "mlx-community/DeepSeek-Coder-V2-Lite-Instruct-4bit-mlx", }, },
   "deepseek-coder-v2.5": { "layers": 60, "repo": { "MLXDynamicShardInferenceEngine": "mlx-community/DeepSeek-V2.5-MLX-AQ4_1_64", }, },
+  "deepseek-v3-0324-8bit": { "layers": 61, "repo": { "MLXDynamicShardInferenceEngine": "mlx-community/DeepSeek-v3-0324-8bit", }, },
   "deepseek-v3": { "layers": 61, "repo": { "MLXDynamicShardInferenceEngine": "mlx-community/DeepSeek-V3-4bit", }, },
   "deepseek-v3-3bit": { "layers": 61, "repo": { "MLXDynamicShardInferenceEngine": "mlx-community/DeepSeek-V3-3bit", }, },
   "deepseek-r1": { "layers": 61, "repo": { "MLXDynamicShardInferenceEngine": "mlx-community/DeepSeek-R1-4bit", }, },
@@ -174,6 +175,7 @@ pretty_name = {
   "mistral-large": "Mistral Large",
   "deepseek-coder-v2-lite": "Deepseek Coder V2 Lite",
   "deepseek-coder-v2.5": "Deepseek Coder V2.5",
+  "deepseek-v3-0324-8bit": "Deepseek V3-0324 (8-bit)",
   "deepseek-v3": "Deepseek V3 (4-bit)",
   "deepseek-v3-3bit": "Deepseek V3 (3-bit)",
   "deepseek-r1": "Deepseek R1 (4-bit)",

--- a/exo/models.py
+++ b/exo/models.py
@@ -88,7 +88,6 @@ model_cards = {
   ### deepseek
   "deepseek-coder-v2-lite": { "layers": 27, "repo": { "MLXDynamicShardInferenceEngine": "mlx-community/DeepSeek-Coder-V2-Lite-Instruct-4bit-mlx", }, },
   "deepseek-coder-v2.5": { "layers": 60, "repo": { "MLXDynamicShardInferenceEngine": "mlx-community/DeepSeek-V2.5-MLX-AQ4_1_64", }, },
-  "deepseek-v3-0324-8bit": { "layers": 61, "repo": { "MLXDynamicShardInferenceEngine": "mlx-community/DeepSeek-v3-0324-8bit", }, },
   "deepseek-v3": { "layers": 61, "repo": { "MLXDynamicShardInferenceEngine": "mlx-community/DeepSeek-V3-4bit", }, },
   "deepseek-v3-3bit": { "layers": 61, "repo": { "MLXDynamicShardInferenceEngine": "mlx-community/DeepSeek-V3-3bit", }, },
   "deepseek-r1": { "layers": 61, "repo": { "MLXDynamicShardInferenceEngine": "mlx-community/DeepSeek-R1-4bit", }, },
@@ -175,7 +174,6 @@ pretty_name = {
   "mistral-large": "Mistral Large",
   "deepseek-coder-v2-lite": "Deepseek Coder V2 Lite",
   "deepseek-coder-v2.5": "Deepseek Coder V2.5",
-  "deepseek-v3-0324-8bit": "Deepseek V3-0324 (8-bit)",
   "deepseek-v3": "Deepseek V3 (4-bit)",
   "deepseek-v3-3bit": "Deepseek V3 (3-bit)",
   "deepseek-r1": "Deepseek R1 (4-bit)",


### PR DESCRIPTION
As numpy doesn't support bfloat16, updated code to check if it is bf16, and if yes, then convert to float32.
also renamed the output_data and first_layer variables to have a better understanding what contains what( like output_data_mx and output_data_np).
Related to https://github.com/exo-explore/exo/issues/799 and https://github.com/exo-explore/exo/issues/811