### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/exo/api/chatgpt_api.py
+++ b/exo/api/chatgpt_api.py
@@ -561,7 +561,11 @@ class ChatGPTAPI:
           except Exception as e:
             if DEBUG >= 2: print(f"Error processing image: {e}")
             if DEBUG >= 2: traceback.print_exc()
-            await response.write(json.dumps({'error': str(e)}).encode('utf-8') + b'\n')
+            # Log the detailed exception information
+            error_details = traceback.format_exc()
+            if DEBUG >= 2: print(error_details)
+            # Send a generic error message to the user
+            await response.write(json.dumps({'error': "An internal error has occurred."}).encode('utf-8') + b'\n')
 
       stream_task = None
 


### PR DESCRIPTION
Potential fix for [https://github.com/digitalmint/exo/security/code-scanning/1](https://github.com/digitalmint/exo/security/code-scanning/1)

To fix the issue, we need to ensure that sensitive exception details are not exposed to external users. Instead of including the exception message (`str(e)`) in the response, we should return a generic error message to the user. The detailed exception information, including the stack trace, should be logged on the server for debugging purposes. This approach aligns with the "GOOD" example in the background section.

Steps to implement the fix:
1. Replace the line that sends the exception message (`str(e)`) to the user with a generic error message, such as `"An internal error has occurred."`.
2. Log the detailed exception information, including the stack trace, using `traceback.format_exc()` or a similar method.
3. Ensure that the fix is applied consistently across all relevant parts of the code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
