### PR TITLE
Potential fix for code scanning alert no. 2: Binding a socket to all network interfaces

### DIFF
--- a/exo/helpers.py
+++ b/exo/helpers.py
@@ -44,7 +44,24 @@ def get_system_info():
   return "Non-Mac, non-Linux system"
 
 
-def find_available_port(host: str = "", min_port: int = 49152, max_port: int = 65535) -> int:
+def find_available_port(host: str, min_port: int = 49152, max_port: int = 65535) -> int:
+  """
+  Finds an available port on the specified host and within the given port range.
+
+  Args:
+      host (str): The IP address of the interface to bind to. Must be explicitly specified.
+      min_port (int): The minimum port number in the range to check (default: 49152).
+      max_port (int): The maximum port number in the range to check (default: 65535).
+
+  Returns:
+      int: An available port number.
+
+  Raises:
+      ValueError: If the host is not specified.
+      RuntimeError: If no available ports are found in the specified range.
+  """
+  if not host:
+      raise ValueError("The 'host' parameter must be explicitly specified to avoid binding to all interfaces.")
   used_ports_file = os.path.join(tempfile.gettempdir(), "exo_used_ports")
 
   def read_used_ports():


### PR DESCRIPTION
Potential fix for [https://github.com/digitalmint/exo/security/code-scanning/2](https://github.com/digitalmint/exo/security/code-scanning/2)

To fix the issue, we will modify the `find_available_port` function to require the caller to explicitly specify the `host` parameter. If the caller does not provide a value, the function will raise a `ValueError` instead of defaulting to an insecure configuration. This ensures that the function cannot inadvertently bind to all interfaces.

Additionally, we will update the function's docstring to clarify the requirement for specifying a dedicated interface.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
